### PR TITLE
Fixed typo

### DIFF
--- a/doc_source/producersdk-cpp-rpi.md
+++ b/doc_source/producersdk-cpp-rpi.md
@@ -216,7 +216,7 @@ If you reboot the device before building the SDK, you must repeat this step\. Yo
 1. Change your current working directory to the install directory:
 
    ```
-   $  cd amazon-kinesis-video-stream-producer-sdk-cpp/kinesis-video-native-build
+   $  cd amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build
    ```
 
 1. Make the install script executable:


### PR DESCRIPTION
*Description of changes:*
In section Build the Kinesis Video Streams C++ Producer SDK after cloning the repo there was a typo on cd command


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
