### PR TITLE
Fixing parameter ordering for docker run

### DIFF
--- a/doc_source/examples-rtsp.md
+++ b/doc_source/examples-rtsp.md
@@ -42,7 +42,7 @@ First, you build the Docker image that the demo application will run inside\.
 Start the Kinesis Video Streams Docker container using the following command\. Provide the image ID from the previous step, your AWS credentials, the URL of your RTSP network camera, and the name of the Kinesis video stream to send the data\.
 
 ```
-$ docker run -it <IMAGE_ID> <AWS_ACCESS_KEY_ID> <AWS_SECRET_ACCESS_KEY> <RTSP_URL> <STREAM_NAME>
+$ docker run -it <IMAGE_ID> <AWS_ACCESS_KEY_ID> <AWS_SECRET_ACCESS_KEY> <STREAM_NAME> <RTSP_URL>
 ```
 
 To customize the application, comment or remove the `ENTRYPOINT` command in `Dockerfile`, and launch the container using the following command:


### PR DESCRIPTION
*Description of changes:*

The Dockerfile source is also wrong, PR created for that one as well: https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/pull/191

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
