### PR TITLE
how-iot: fix iam-policy-document.json example error

### DIFF
--- a/doc_source/how-iot.md
+++ b/doc_source/how-iot.md
@@ -60,15 +60,15 @@ Perform the following steps to create and configure this IAM role:
 
    ```
    {
-      "Version":"2012-10-17",
-      "Statement":[
+      "Version": "2012-10-17",
+      "Statement": [
          {
-   	 "Effect":"Allow",
-   	 "Principal":{
-   	    "Service":"credentials.iot.amazonaws.com"
-       },
-   	 "Action":"sts:AssumeRole"
-    }
+               "Effect": "Allow",
+               "Principal": {
+                  "Service": "credentials.iot.amazonaws.com"
+               },
+               "Action": "sts:AssumeRole"
+         }
       ]
    }
    ```


### PR DESCRIPTION
Current policy json will case createRole operation error "This policy contains invalid Json "

Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
