### PR TITLE
Fixed Raspberry Pi OS download link

### DIFF
--- a/doc_source/gs-createstream.md
+++ b/doc_source/gs-createstream.md
@@ -8,9 +8,9 @@ This section contains the following procedures:
 
 ## Create a Video Stream Using the Console<a name="gs-createstream-console"></a>
 
-1. Sign in to the AWS Management Console and open the Kinesis console at [https://console\.aws\.amazon\.com/kinesis](https://console.aws.amazon.com/kinesis)\.
+1. Sign in to the AWS Management Console and open the Kinesis Video Streams console at [https://console\.aws\.amazon\.com/kinesisvideo/home](https://console.aws.amazon.com/kinesisvideo/home)\.
 
-1. On the **Video streams** page, choose **Create video stream**\.
+1. In the **New Kinesis Video Streams resource** block, choose **Video stream** and choose **Create** button\.
 
 1. On the **Create a new video stream** page, type **ExampleStream** for the stream name\. Leave the **Default configuration** radio button selected\. 
 

--- a/doc_source/producersdk-cpp-rpi.md
+++ b/doc_source/producersdk-cpp-rpi.md
@@ -19,7 +19,7 @@ Before you set up the C\+\+ Producer SDK on your Raspberry Pi, ensure that you h
   + Board version: 3 Model B or later\.
   + A connected camera module\.
   + An SD card with a capacity of at least 8 GB\.
-  + The Raspbian operating system \(kernel version 4\.9 or later\) installed\. You can download the latest Raspbian image from the [Raspberry Pi Foundation website](https://www.raspberrypi.org/downloads/raspbian/)\. Follow the Raspberry Pi instructions to [install the downloaded image on an SD card](https://www.raspberrypi.org/documentation/installation/installing-images/README.md)\. 
+  + The Raspbian operating system \(kernel version 4\.9 or later\) installed\. You can download the latest Raspbian image from the [Raspberry Pi Foundation website](https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit)\. Follow the Raspberry Pi instructions to [install the downloaded image on an SD card](https://www.raspberrypi.org/documentation/installation/installing-images/README.md)\. 
 + An AWS account with a Kinesis video stream\. For more information, see [Getting Started with Kinesis Video Streams](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/getting-started.html)\.
 **Note**  
 The C\+\+ Producer SDK uses the US West \(Oregon\) \(`us-west-2`\) Region by default\. To use the default AWS Region, create your Kinesis video stream in the US West \(Oregon\) Region\.   


### PR DESCRIPTION
- [x] The page [https://www.raspberrypi.org/downloads/raspbian/](https://www.raspberrypi.org/downloads/raspbian/) does not exist (HTTP 404 Not Found). Replaced with: [https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit](https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit)
- [x] Replaced "Kinesis" [https://console\.aws\.amazon\.com/kinesis/home](https://console.aws.amazon.com/kinesis/home) with "Kinesis Video Streams" [https://console\.aws\.amazon\.com/kinesisvideo/home](https://console.aws.amazon.com/kinesisvideo/home) link. Corrected the second step of the description to match the new page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
